### PR TITLE
add notepack implementation

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -21,6 +21,10 @@ var Benchmark = require('benchmark')
       encode: require('msgpack-lite').encode,
       decode: require('msgpack-lite').decode
     },
+    'notepack': {
+      encode: require('notepack').encode,
+      decode: require('notepack').decode
+    },
     'JSON': {
       encode: JSON.stringify,
       decode: JSON.parse

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "msgpack-js-browser": "^0.1.4",
     "msgpack-js-v5": "^0.3.0-v5",
     "msgpack-lite": "^0.1.13",
-    "msgpack5": "^3.3.0"
+    "msgpack5": "^3.3.0",
+    "notepack": "0.0.2"
   }
 }


### PR DESCRIPTION
The results on my machine:
```
sample-datatypes.json:
(encode) msgpack x 40,273 ops/sec ±3.68% (99 runs sampled) 
(encode) msgpack-javascript x 57,092 ops/sec ±2.14% (98 runs sampled)
(encode) msgpack-js-v5 x 14,574 ops/sec ±0.58% (92 runs sampled)
(encode) msgpack-lite x 55,791 ops/sec ±1.65% (86 runs sampled)
(encode) notepack x 71,068 ops/sec ±0.14% (102 runs sampled)
(encode) JSON x 161,920 ops/sec ±3.06% (97 runs sampled)

(decode) msgpack x 43,621 ops/sec ±0.08% (98 runs sampled)
(decode) msgpack-javascript x 30,638 ops/sec ±0.34% (103 runs sampled)
(decode) msgpack-js-v5 x 27,639 ops/sec ±0.15% (102 runs sampled)
(decode) msgpack-lite x 47,547 ops/sec ±0.20% (102 runs sampled)
(decode) notepack x 51,030 ops/sec ±0.25% (100 runs sampled)
(decode) JSON x 89,312 ops/sec ±0.30% (99 runs sampled)

sample-small.json:
(encode) msgpack x 216,739 ops/sec ±3.10% (90 runs sampled)
(encode) msgpack-javascript x 690,638 ops/sec ±0.21% (103 runs sampled)
(encode) msgpack-js-v5 x 116,748 ops/sec ±0.49% (96 runs sampled)
(encode) msgpack-lite x 279,805 ops/sec ±2.96% (88 runs sampled)
(encode) notepack x 626,992 ops/sec ±3.89% (94 runs sampled)
(encode) JSON x 941,227 ops/sec ±2.06% (92 runs sampled)

(decode) msgpack x 276,342 ops/sec ±0.21% (102 runs sampled)
(decode) msgpack-javascript x 461,674 ops/sec ±0.29% (100 runs sampled)
(decode) msgpack-js-v5 x 292,926 ops/sec ±0.39% (101 runs sampled)
(decode) msgpack-lite x 553,139 ops/sec ±0.20% (102 runs sampled)
(decode) notepack x 682,412 ops/sec ±0.18% (101 runs sampled)
(decode) JSON x 996,394 ops/sec ±0.38% (100 runs sampled)

sample-medium.json:
(encode) msgpack x 116,469 ops/sec ±2.24% (94 runs sampled)
(encode) msgpack-javascript x 336,313 ops/sec ±0.92% (96 runs sampled)
(encode) msgpack-js-v5 x 36,166 ops/sec ±1.58% (94 runs sampled)
(encode) msgpack-lite x 139,615 ops/sec ±2.37% (95 runs sampled)
(encode) notepack x 240,649 ops/sec ±0.09% (101 runs sampled)
(encode) JSON x 607,312 ops/sec ±0.11% (97 runs sampled)

(decode) msgpack x 150,457 ops/sec ±0.12% (102 runs sampled)
(decode) msgpack-javascript x 117,914 ops/sec ±0.34% (101 runs sampled)
(decode) msgpack-js-v5 x 73,643 ops/sec ±0.15% (99 runs sampled)
(decode) msgpack-lite x 128,643 ops/sec ±0.15% (99 runs sampled)
(decode) notepack x 149,283 ops/sec ±4.48% (94 runs sampled)
(decode) JSON x 486,974 ops/sec ±0.70% (103 runs sampled)

sample-large.json:
(encode) msgpack x 7,870 ops/sec ±0.40% (98 runs sampled)
(encode) msgpack-javascript x 10,311 ops/sec ±0.22% (102 runs sampled)
(encode) msgpack-js-v5 x 1,861 ops/sec ±2.15% (98 runs sampled)
(encode) msgpack-lite x 8,937 ops/sec ±1.48% (99 runs sampled)
(encode) notepack x 13,276 ops/sec ±0.40% (102 runs sampled)
(encode) JSON x 36,905 ops/sec ±0.20% (101 runs sampled)

(decode) msgpack x 9,475 ops/sec ±0.21% (102 runs sampled)
(decode) msgpack-javascript x 4,272 ops/sec ±0.33% (102 runs sampled)
(decode) msgpack-js-v5 x 3,858 ops/sec ±0.31% (101 runs sampled)
(decode) msgpack-lite x 7,903 ops/sec ±0.35% (101 runs sampled)
(decode) notepack x 8,426 ops/sec ±0.29% (102 runs sampled)
(decode) JSON x 13,487 ops/sec ±0.42% (101 runs sampled)
```